### PR TITLE
Fix CSV Fieldname Mismatch Error

### DIFF
--- a/informationalcontent.py
+++ b/informationalcontent.py
@@ -77,6 +77,7 @@ def process_content_plan():
     input_file = 'content_plan.csv'
     output_file = 'processed_content_plan.csv'
     processed_rows = []
+    all_fieldnames = set()
 
     with open(input_file, newline='', encoding='utf-8') as csvfile:
         reader = csv.DictReader(csvfile)
@@ -91,9 +92,10 @@ def process_content_plan():
             if outline and article:
                 row.update({'Blog Outline': outline, 'Article': article, 'Processed': 'Yes'})
                 processed_rows.append(row)
+                all_fieldnames.update(row.keys())
 
     with open(output_file, 'w', newline='', encoding='utf-8') as f:
-        writer = csv.DictWriter(f, fieldnames=processed_rows[0].keys())
+        writer = csv.DictWriter(f, fieldnames=all_fieldnames)
         writer.writeheader()
         writer.writerows(processed_rows)
 


### PR DESCRIPTION
The proposed edit addresses the issue of a ValueError encountered during the CSV writing process in the `process_content_plan` function.

The error was caused by a mismatch that sometimes occurred between the fieldnames expected by `csv.DictWriter` and the actual keys present in the dictionaries in `processed_rows`, depending on the result returned by process_blog_post().

Changes made:
- Introduced a set `all_fieldnames` to dynamically collect all unique fieldnames from each row in the input CSV. This approach ensures that the fieldnames list used by `csv.DictWriter` is comprehensive and accommodates any variation in the keys present across different rows.
- Updated the CSV writing block to use this dynamically generated list of fieldnames, thereby preventing the `ValueError: dict contains fields not in fieldnames: None`.

These enhancements make the script slightly more robust in scenarios where different rows might have slightly different sets of keys.